### PR TITLE
pcsx-rearmed: bump to b76bab8 and make a few small fixes

### DIFF
--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-pcsx-rearmed"
-PKG_VERSION="3c4ac5bb44b41d23eec217369eaa34f4e155f733"
-PKG_SHA256="9ab6a392266319b8897f2129dff88f025990218fb4a47354879649c2e9e4befe"
+PKG_VERSION="b76bab8002d203f74e854072b6964138ede0a967"
+PKG_SHA256="86fb7d252d608cdaa520e70047631a62497e550132df8ebebc5f31dada32016b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/$PKG_VERSION.tar.gz"
@@ -21,6 +21,7 @@ make_target() {
   
   if target_has_feature neon; then
     export HAVE_NEON=1
+    export BUILTIN_GPU=neon
    else
     export HAVE_NEON=0
   fi
@@ -30,7 +31,7 @@ make_target() {
       make -f Makefile.libretro platform=aarch64 GIT_VERSION=$PKG_VERSION
       ;;
     arm)
-      make -f Makefile.libretro USE_DYNAREC=1 GIT_VERSION=$PKG_VERSION
+      make -f Makefile.libretro DYNAREC=ari64 GIT_VERSION=$PKG_VERSION
       ;;
     x86_64)
       make -f Makefile.libretro GIT_VERSION=$PKG_VERSION

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="game.libretro.pcsx-rearmed"
 PKG_VERSION="22.0.0.9-Leia"
 PKG_SHA256="d19740346723a8900284006972d6c5fae6ef5aed177c3b6928558790ff949a95"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pcsx-rearmed"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/sources/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/sources/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,193 @@
+# game.libretro.pcsx-rearmed language file
+# Addon Name: game.libretro.pcsx-rearmed
+# Addon id: game.libretro.pcsx-rearmed
+# Addon Provider: libretro
+msgid ""
+msgstr ""
+"Project-Id-Version: game.libretro.pcsx-rearmed\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2017-02-04 09:56i\n"
+"PO-Revision-Date: 2017-02-04 09:56i\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30000"
+msgid "Settings"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Analog axis bounds."
+msgstr ""
+
+msgctxt "#30002"
+msgid "CD Access Method (Restart)"
+msgstr ""
+
+msgctxt "#30003"
+msgid "Use BIOS"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Display Internal FPS"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Enable Dithering"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Dynamic Recompiler"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Frame Duping"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Frameskip"
+msgstr ""
+
+msgctxt "#30009"
+msgid "(GPU) Enable Interlacing Mode"
+msgstr ""
+
+msgctxt "#30010"
+msgid "(GPU) Enhanced Resolution (Slow)"
+msgstr ""
+
+msgctxt "#30011"
+msgid "(GPU) Enhanced Resolution (Speed Hack)"
+msgstr ""
+
+msgctxt "#30018"
+msgid "(Speed Hack) Assume GTE Regs Unneeded"
+msgstr ""
+
+msgctxt "#30019"
+msgid "Guncon Adjust Ratio X"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Guncon Adjust Ratio Y"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Guncon Adjust X"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Guncon Adjust Y"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Diablo Music Fix"
+msgstr ""
+
+msgctxt "#30024"
+msgid "InuYasha Sengoku Battle Fix"
+msgstr ""
+
+msgctxt "#30025"
+msgid "Enable Second Memory Card (Shared)"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Multitap 1"
+msgstr ""
+
+msgctxt "#30027"
+msgid "Multitap 2"
+msgstr ""
+
+msgctxt "#30028"
+msgid "NegCon Twist Deadzone (Percent)"
+msgstr ""
+
+msgctxt "#30029"
+msgid "NegCon Twist Response"
+msgstr ""
+
+msgctxt "#30030"
+msgid "CD Audio"
+msgstr ""
+
+msgctxt "#30031"
+msgid "(Speed Hack) Disable GTE Flags"
+msgstr ""
+
+msgctxt "#30032"
+msgid "(Speed Hack) Disable SMC Checks"
+msgstr ""
+
+msgctxt "#30033"
+msgid "XA Decoding"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Pad 1 Type"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Pad 2 Type"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Pad 3 Type"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Pad 4 Type"
+msgstr ""
+
+msgctxt "#30038"
+msgid "Pad 5 Type"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Pad 6 Type"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Pad 7 Type"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Pad 8 Type"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Parasite Eve 2/Vandal Hearts 1/2 Fix"
+msgstr ""
+
+msgctxt "#30043"
+msgid "PSX CPU Clock"
+msgstr ""
+
+msgctxt "#30044"
+msgid "Region"
+msgstr ""
+
+msgctxt "#30045"
+msgid "Show Bios Bootlogo"
+msgstr ""
+
+msgctxt "#30046"
+msgid "Sound Interpolation"
+msgstr ""
+
+msgctxt "#30047"
+msgid "Sound Reverb"
+msgstr ""
+
+msgctxt "#30048"
+msgid "SPU IRQ Always Enabled"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Enable Vibration"
+msgstr ""

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/sources/game.libretro.pcsx-rearmed/resources/settings.xml
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/sources/game.libretro.pcsx-rearmed/resources/settings.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+	<category label="30000">
+		<setting label="30001" type="select" id="pcsx_rearmed_analog_axis_modifier" values="circle|square" default="circle"/>
+		<setting label="30002" type="select" id="pcsx_rearmed_async_cd" values="sync|async" default="sync"/>
+		<setting label="30003" type="select" id="pcsx_rearmed_bios" values="auto|HLE" default="auto"/>
+		<setting label="30004" type="select" id="pcsx_rearmed_display_internal_fps" values="disabled|enabled" default="disabled"/>
+		<setting label="30005" type="select" id="pcsx_rearmed_dithering" values="enabled|disabled" default="enabled"/>
+		<setting label="30006" type="select" id="pcsx_rearmed_drc" values="enabled|disabled" default="enabled"/>
+		<setting label="30007" type="select" id="pcsx_rearmed_duping_enable" values="enabled|disabled" default="enabled"/>
+		<setting label="30008" type="select" id="pcsx_rearmed_frameskip" values="0|1|2|3" default="0"/>
+		<setting label="30009" type="select" id="pcsx_rearmed_neon_interlace_enable" values="disabled|enabled" default="disabled"/>
+		<setting label="30010" type="select" id="pcsx_rearmed_neon_enhancement_enable" values="disabled|enabled" default="disabled"/>
+		<setting label="30011" type="select" id="pcsx_rearmed_neon_enhancement_no_main" values="disabled|enabled" default="disabled"/>
+		<setting label="30018" type="select" id="pcsx_rearmed_gteregsunneeded" values="disabled|enabled" default="disabled"/>
+		<setting label="30019" type="select" id="pcsx_rearmed_gunconadjustratiox" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
+		<setting label="30020" type="select" id="pcsx_rearmed_gunconadjustratioy" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
+		<setting label="30021" type="select" id="pcsx_rearmed_gunconadjustx" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
+		<setting label="30022" type="select" id="pcsx_rearmed_gunconadjusty" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
+		<setting label="30023" type="select" id="pcsx_rearmed_idiablofix" values="disabled|enabled" default="disabled"/>
+		<setting label="30024" type="select" id="pcsx_rearmed_inuyasha_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30025" type="select" id="pcsx_rearmed_memcard2" values="disabled|enabled" default="disabled"/>
+		<setting label="30026" type="select" id="pcsx_rearmed_multitap1" values="auto|disabled|enabled" default="auto"/>
+		<setting label="30027" type="select" id="pcsx_rearmed_multitap2" values="auto|disabled|enabled" default="auto"/>
+		<setting label="30028" type="select" id="pcsx_rearmed_negcon_deadzone" values="0|5|10|15|20|25|30" default="0"/>
+		<setting label="30029" type="select" id="pcsx_rearmed_negcon_response" values="linear|quadratic|cubic" default="linear"/>
+		<setting label="30030" type="select" id="pcsx_rearmed_nocdaudio" values="enabled|disabled" default="enabled"/>
+		<setting label="30031" type="select" id="pcsx_rearmed_nogteflags" values="disabled|enabled" default="disabled"/>
+		<setting label="30032" type="select" id="pcsx_rearmed_nosmccheck" values="disabled|enabled" default="disabled"/>
+		<setting label="30033" type="select" id="pcsx_rearmed_noxadecoding" values="enabled|disabled" default="enabled"/>
+		<setting label="30034" type="select" id="pcsx_rearmed_pad1type" values="standard|analog|dualshock|negcon|guncon|none" default="standard"/>
+		<setting label="30035" type="select" id="pcsx_rearmed_pad2type" values="standard|analog|dualshock|negcon|guncon|none" default="standard"/>
+		<setting label="30036" type="select" id="pcsx_rearmed_pad3type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30037" type="select" id="pcsx_rearmed_pad4type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30038" type="select" id="pcsx_rearmed_pad5type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30039" type="select" id="pcsx_rearmed_pad6type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30040" type="select" id="pcsx_rearmed_pad7type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30041" type="select" id="pcsx_rearmed_pad8type" values="none|standard|analog|dualshock|negcon|guncon" default="none"/>
+		<setting label="30042" type="select" id="pcsx_rearmed_pe2_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30043" type="select" id="pcsx_rearmed_psxclock" values="57|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|58|59|60|61|62|63|64|65|66|67|68|69|70|71|72|73|74|75|76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94|95|96|97|98|99|100" default="57"/>
+		<setting label="30044" type="select" id="pcsx_rearmed_region" values="auto|NTSC|PAL" default="auto"/>
+		<setting label="30045" type="select" id="pcsx_rearmed_show_bios_bootlogo" values="disabled|enabled" default="disabled"/>
+		<setting label="30046" type="select" id="pcsx_rearmed_spu_interpolation" values="simple|gaussian|cubic|off" default="simple"/>
+		<setting label="30047" type="select" id="pcsx_rearmed_spu_reverb" values="enabled|disabled" default="enabled"/>
+		<setting label="30048" type="select" id="pcsx_rearmed_spuirq" values="disabled|enabled" default="disabled"/>
+		<setting label="30049" type="select" id="pcsx_rearmed_vibration" values="enabled|disabled" default="enabled"/>
+	</category>
+</settings>


### PR DESCRIPTION
This is a bit of a mess but good enough to restore a working
version of the addon, until upstream bumps and we work out a
way of dealing with situation of game.libretro.pcsx-rearmed
needing to be modified for CE.