### PR TITLE
Odroid N2+: reset USB hub when using Wake-On-LAN

### DIFF
--- a/projects/Amlogic-ng/filesystem/usr/lib/systemd/system-sleep/reset_usb_hub.sh
+++ b/projects/Amlogic-ng/filesystem/usr/lib/systemd/system-sleep/reset_usb_hub.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020-present Team CoreELEC (https://coreelec.org)
+
+case "$1" in
+  pre)
+    # <do something on suspend>
+    ;;
+  post)
+    # <do something on resume>
+    DT_ID=$(cat /proc/device-tree/coreelec-dt-id)
+    case $DT_ID in
+      *odroid_n2plus*)
+        wol="$(cat /flash/config.ini | awk -F "=" '/^wol=/{gsub(/"|\047/,"",$2); print $2}')"
+        if [ "$wol" == "1" ]; then
+          echo "reset" > /sys/devices/platform/gpio-reset/reset-usb_hub/control
+        fi
+        ;;
+    esac
+    ;;
+esac


### PR DESCRIPTION
When using Wake-On-LAN the USB hub need to be reset after resume from suspend.