### PR TITLE
scripts/get_archive: Allow the use of GitHub Tokens

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -32,8 +32,16 @@ rm -f "${STAMP_URL}" "${STAMP_SHA}"
 NBWGET=10
 while [ ${NBWGET} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
+    if [[ "$PKG_USETOKEN" == "yes" ]]; then
+      if [[ $url == https://github.com/* ]] && [[ -n $COREELEC_GHTOKEN ]]; then
+        WGET_HEADER=--header="Authorization: token $COREELEC_GHTOKEN"
+      fi
+    else
+      WGET_HEADER=--header=""
+    fi
+
     rm -f "${PACKAGE}"
-    if ${WGET_CMD} "${url}"; then
+    if ${WGET_CMD} "$WGET_HEADER" "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2


### PR DESCRIPTION
You can define COREELEC_GHTOKEN in your ~/.coreelec/options file.
This is usefull if you are testing some development changes in a private
GitHub repo before pushing it to a public one.
This Token is sent in an additional Header only to https://github.com/.
Also this is restricted to packages that define PKG_USETOKEN=yes.

Co-authored-by: Raybuntu <57228613+Raybuntu@users.noreply.github.com>