### PR TITLE
aml-vnc: add patch to fix compiling

### DIFF
--- a/packages/addons/service/aml-vnc/patches/aml-vnc-03-Fix-compiling-with-GCC-10.patch
+++ b/packages/addons/service/aml-vnc/patches/aml-vnc-03-Fix-compiling-with-GCC-10.patch
@@ -1,0 +1,48 @@
+From 7483cbd4375ee592d06019f70871445e60e669e3 Mon Sep 17 00:00:00 2001
+From: Portisch <hugo.portisch@yahoo.de>
+Date: Fri, 4 Dec 2020 10:07:31 +0100
+Subject: [PATCH] Fix compiling with GCC-10
+
+---
+ common.h      | 2 +-
+ framebuffer.c | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/common.h b/common.h
+index c294fa4..b74d66a 100644
+--- a/common.h
++++ b/common.h
+@@ -75,7 +75,7 @@ int getCurrentRotation();
+ int isIdle();
+ void setIdle(int i);
+ void close_app();
+-screenFormat screenformat;
++extern screenFormat screenformat;
+ 
+ #define ARR_LEN(a) (sizeof(a)/sizeof(a)[0])
+ 
+diff --git a/framebuffer.c b/framebuffer.c
+index 741c922..2620c0a 100644
+--- a/framebuffer.c
++++ b/framebuffer.c
+@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ #include "framebuffer.h"
+ #include <limits.h>
+ 
++screenFormat screenformat;
++
+ int fbfd = -1;
+ unsigned int *fbmmap;
+ 
+@@ -47,7 +49,7 @@ void update_fb_info(void) {
+ }
+ 
+ inline int roundUpToPageSize(int x) {
+-	return (x + (getpagesize()-1)) & ~(getpagesize()-1);
++	return (x + (sysconf(_SC_PAGESIZE)-1)) & ~(sysconf(_SC_PAGESIZE)-1);
+ }
+ 
+ int initFB(void) {
+-- 
+2.29.2
+


### PR DESCRIPTION
'getpagesize' is obsolete and undefined